### PR TITLE
fix: update ES::Plugin::Wrapper::Result to NeedResize rather than Failure

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -34,7 +34,7 @@ int main()
         {
             glfwPollEvents();
 
-            if (vkWrapper.DrawFrame() == ES::Plugin::Wrapper::Result::Failure)
+            if (vkWrapper.DrawFrame() == ES::Plugin::Wrapper::Result::NeedResize)
                 vkWrapper.Resize(window.GetGLFWWindow());
         }
 


### PR DESCRIPTION
With modification requested in [this PR](https://github.com/EngineSquared/EngineSquared/pull/47) it create a breaking change in this project.